### PR TITLE
Adding scripts checkout example

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 Fixes #
 
 **Problem description**
-Briefly describe the technical requirements of the feature implementetion in case the PR is introducing a feature, or describe the root cause and analysis of the issue in case the PR is fixing a bug.
+Briefly describe the technical requirements of the feature implementation in case the PR is introducing a feature, or describe the root cause and analysis of the issue in case the PR is fixing a bug.
 
 **Solution description**
 Describe the code changes in details for the reviewers. Explain the technical solution you have provided and how it implements/fixes the issue.

--- a/.github/workflows/example_checkout_scripts.yaml
+++ b/.github/workflows/example_checkout_scripts.yaml
@@ -1,4 +1,4 @@
-name: Checkout scripts repo
+name: Example checkout scripts
 on:
   pull_request
 jobs:

--- a/.github/workflows/example_checkout_scripts.yaml
+++ b/.github/workflows/example_checkout_scripts.yaml
@@ -3,13 +3,28 @@ on:
   pull_request
 jobs:
   scripts_nested:
-    name: Checkout repo with scripts
+    name: Checkout repo with scripts nested
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout current repo
+      - name: Checkout current
         uses: actions/checkout@v2
 
-      - name: Checkout scripts repo
+      - name: Add scripts nested
+        uses: actions/checkout@v2
+        with:
+          repository: geriremenyi/github-action-scripts
+          path: scripts
+  
+  scripts_side_by_side:
+    name: Checkout repo with scripts SxS
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          path: main
+
+      - name: Checkout tools repo
         uses: actions/checkout@v2
         with:
           repository: geriremenyi/github-action-scripts

--- a/.github/workflows/example_checkout_scripts.yaml
+++ b/.github/workflows/example_checkout_scripts.yaml
@@ -1,0 +1,16 @@
+name: Checkout scripts repo
+on:
+  pull_request
+jobs:
+  scripts_nested:
+    name: Checkout repo with scripts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout current repo
+        uses: actions/checkout@v2
+
+      - name: Checkout scripts repo
+        uses: actions/checkout@v2
+        with:
+          repository: geriremenyi/github-action-scripts
+          path: scripts


### PR DESCRIPTION
**Problem description**
Checking out scripts repo is a common task within GitHub actions and repeated across repos and workflow definitions. Currently there is no common place where the example job definition is persisted.

**Solution description**
Adding two job definitions in the `example_checkout_scripts.yaml` to have examples of checking out the `geriremenyi/github-action-scripts` repo nested into the _current_ repo or side by side with it.  